### PR TITLE
CI: Impact diff PR comment (nekoimpact diff)

### DIFF
--- a/.github/workflows/impact-diff.yml
+++ b/.github/workflows/impact-diff.yml
@@ -1,0 +1,55 @@
+name: Impact Diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  impact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Fetch base ref
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Impact diff
+        env:
+          INCLUDE_WORKING: "false"
+        run: |
+          chmod +x scripts/impact-diff.sh || true
+          scripts/impact-diff.sh "origin/${{ github.base_ref }}" impact.md
+
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file impact.md || true
+          else
+            BODY=$(jq -Rs . < impact.md)
+            curl -sS -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -X POST \
+              -d "{\"body\": $BODY}" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" || true
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: impact-diff
+          path: impact.md

--- a/scripts/impact-diff.sh
+++ b/scripts/impact-diff.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+BIN_DIR="$ROOT_DIR/target/release"
+FALLBACK_DIR="$ROOT_DIR/releases"
+
+NEKOCODE="$BIN_DIR/nekocode"
+NEKOIMPACT="$BIN_DIR/nekoimpact"
+
+COMPARE_REF="${1:-origin/main}"
+OUT_FILE="${2:-}"
+INCLUDE_WORKING="${INCLUDE_WORKING:-false}"
+
+# Build if target binaries missing; otherwise fallback to releases
+if [[ ! -x "$NEKOCODE" || ! -x "$NEKOIMPACT" ]]; then
+  if [[ -x "$FALLBACK_DIR/nekocode" && -x "$FALLBACK_DIR/nekoimpact" ]]; then
+    NEKOCODE="$FALLBACK_DIR/nekocode"
+    NEKOIMPACT="$FALLBACK_DIR/nekoimpact"
+  else
+    echo "::group::Build binaries"
+    cargo build --release
+    echo "::endgroup::"
+  fi
+fi
+
+chmod +x "$NEKOCODE" "$NEKOIMPACT" || true
+
+echo "::group::Create session"
+SESSION_OUTPUT=$("$NEKOCODE" session-create "$ROOT_DIR" -n ci_impact || true)
+echo "$SESSION_OUTPUT"
+SESSION_ID=$(echo "$SESSION_OUTPUT" | sed -n 's/.*Created session: \([A-Za-z0-9_-]*\).*/\1/p' | tail -n1)
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID=$("$NEKOCODE" session-list --detailed | sed -n 's/^🆔 \([A-Za-z0-9_-]*\).*/\1/p' | head -n1)
+fi
+echo "SESSION_ID=$SESSION_ID"
+echo "::endgroup::"
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "Error: Failed to obtain session id" >&2
+  exit 2
+fi
+
+INCLUDE_FLAG=()
+if [[ "$INCLUDE_WORKING" == "true" ]]; then
+  INCLUDE_FLAG+=("--include-working")
+fi
+
+echo "::group::Run impact diff ($COMPARE_REF)"
+COMMENT=$("$NEKOIMPACT" diff "$SESSION_ID" --compare-ref "$COMPARE_REF" "${INCLUDE_FLAG[@]}" --format github-comment || true)
+echo "$COMMENT"
+echo "::endgroup::"
+
+if [[ -n "$OUT_FILE" ]]; then
+  printf "%s\n" "$COMMENT" >"$OUT_FILE"
+fi
+
+exit 0


### PR DESCRIPTION
This PR adds a CI workflow and helper script to build the binaries and post an impact diff (nekoimpact diff) as a PR comment.\n\n- scripts/impact-diff.sh: builds if needed, runs nekocode session + nekoimpact diff, outputs github-comment\n- .github/workflows/impact-diff.yml: checkout, setup rust, fetch base ref, run script, post comment and upload artifact\n\nAdjustments welcome for formatting, thresholds, and base ref handling.